### PR TITLE
Support for AWS Neptune

### DIFF
--- a/scripts/graphConf.js
+++ b/scripts/graphConf.js
@@ -1,11 +1,11 @@
 
 // configuration for the graph database access
-const HOST = "josh-test.cluster-cnyckbjgsrik.us-east-1-beta.rds.amazonaws.com"
+const HOST = "localhost"
 const PORT = "8182"
 
 // for implementations like Neptune where only single commands are allowed per request
 // set to true
-const SINGLE_COMMANDS_AND_NO_VARS = true;
+const SINGLE_COMMANDS_AND_NO_VARS = false;
 
 
 // The communication protocol with the server can be "REST" or "websocket"
@@ -15,8 +15,8 @@ const COMMUNICATION_PROTOCOL = "REST";
 
 // The communication method can be GraphSON 1.0 (used by Gremlin 3.2)
 // or GraphSON 3.0 (used by Gremlin 3.3)
-//const COMMUNICATION_METHOD = "GraphSON1"
-const COMMUNICATION_METHOD = "GraphSON3"
+const COMMUNICATION_METHOD = "GraphSON1"
+//const COMMUNICATION_METHOD = "GraphSON3"
 
 // Graph configuration
 const default_nb_of_layers = 3;

--- a/scripts/graphConf.js
+++ b/scripts/graphConf.js
@@ -1,7 +1,13 @@
 
 // configuration for the graph database access
-const HOST = "localhost"
+const HOST = "josh-test.cluster-cnyckbjgsrik.us-east-1-beta.rds.amazonaws.com"
 const PORT = "8182"
+
+// for implementations like Neptune where only single commands are allowed per request
+// set to true
+const SINGLE_COMMANDS_AND_NO_VARS = true;
+
+
 // The communication protocol with the server can be "REST" or "websocket"
 const COMMUNICATION_PROTOCOL = "REST";
 //const COMMUNICATION_PROTOCOL = "websocket";
@@ -9,8 +15,8 @@ const COMMUNICATION_PROTOCOL = "REST";
 
 // The communication method can be GraphSON 1.0 (used by Gremlin 3.2)
 // or GraphSON 3.0 (used by Gremlin 3.3)
-const COMMUNICATION_METHOD = "GraphSON1"
-//const COMMUNICATION_METHOD = "GraphSON3"
+//const COMMUNICATION_METHOD = "GraphSON1"
+const COMMUNICATION_METHOD = "GraphSON3"
 
 // Graph configuration
 const default_nb_of_layers = 3;


### PR DESCRIPTION
Amazon Web Services announced a new graph database called Neptune. It supports Gremlin and the TinkerPop stack. I have access to the preview and was using your tool to inspect data I had ingested, but ran into some problems. The gremlin server for Neptune does not allow multiple commands per script/query or using variables. 

The changes in this pull let your tool work with Neptune with a simple config change. Once Neptune becomes publicly available, there will likely be a lot of people hoping your tool is compatible. Whether or not you want to take my code, it'd be a good idea, in my opinion, to make your handy tool compatible.