### PR TITLE
Don't add a table row in the element info box for property summaries

### DIFF
--- a/scripts/infobox.js
+++ b/scripts/infobox.js
@@ -138,6 +138,10 @@ var infobox = (function(){
 
 	function _display_vertex_properties(key,value,info_table) {
  		for (var subkey in value){
+			// Ignore the summary field, which is set in graphioGremlin.extract_infov3()
+			if (subkey === "summary") {
+				continue;
+			}
  			if ( ((typeof value[subkey] === "object") && (value[subkey] !== null)) && ('properties' in value[subkey]) ){
  				for (var subsubkey in value[subkey].properties){
  					var new_info_row = info_table.append("tr");


### PR DESCRIPTION
Issue: #10 

The reason this was happening lies in the fact that each vertex property is assigned a `summary` property in graphioGremlin.js; when the properties are being displayed in the info box, their values are iterated over, which picks up this extra `summary` field. I don't usually work on Javascript, but in my opinion, the code should be refactored to make each vertex property a dict with a `summary` field and a `properties`, instead of attaching a `summary` property to an array; however, that would be a much larger change. This addition will suffice as a band-aid.