### PR TITLE
Update graphexp.html

### DIFF
--- a/graphexp.html
+++ b/graphexp.html
@@ -73,7 +73,7 @@
 					<svg></svg>
 				</div>
 
-				<div class="aside left_bar" style="background-color:transparent;pointer-events:none;">
+				<div class="aside left_bar" style="background-color:transparent;pointer-events:auto;">
 					<div  id="graphInfoBar" style="background-color:transparent;pointer-events:auto;">
 						<button name="graphInfo" onclick="get_graph_info();">Get graph info</button>
 						<input type="checkbox" name="showgraphinfo" id="showgraphinfo" onchange="show_hide_element('#graphInfo')"/>Show/hide graph info
@@ -82,7 +82,7 @@
 					</div>
 				</div>
 
-				<div class="aside right_bar" id="details" style="background-color:transparent;pointer-events:none;">
+				<div class="aside right_bar" id="details" style="background-color:transparent;pointer-events:auto;">
 					<div id="messageArea"></div><div id="outputArea"></div>
 					<div id="nodeInfo" style="background-color:transparent;pointer-events:none;">
 					</div>				


### PR DESCRIPTION
#17 
Makes info boxes selectable to allow copying data. By necessity you can only interact with the visualization in the empty space between the left and right boxes (if displayed) but this is much more intuitive than wholly blocking interaction with the text. Note, if this is a major problem, setting some max width formatting on the info boxes would be good.