### PR TITLE
Fixing X or Y coordinates

### DIFF
--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -426,6 +426,12 @@ var graphioGremlin = (function(){
 			}
 			//property = property.toString();
 			data_dic.properties[key] = property;
+			if (key == 'graphexpx') {
+				data_dic.fx = prop_dic['graphexpx']['0']['value'];
+			}
+			if (key == 'graphexpy') {
+				data_dic.fy = prop_dic['graphexpy']['0']['value'];
+			}
 		}
 	}
 	if (data.type=="edge"){


### PR DESCRIPTION
Change to graphioGremlin.js extract_infov3 so that if vertex properties "graphexpx" or "graphexpy" are found in Gremlin DB (they should have numerical values) then these are used to constrain the x or y coordinates of the nodes in the visualisation. Any dimension which is not constrained, as well as any nodes which are not constrained in either dimension, are subject to the force simulation. Thus, adding only "graphexpy" properties can be used to display hierarchies, whether local or global, that may exist in your data. I recommend multiplying each desired hierarchical level by 50-100 in the first case in order to work well with the default graphexp visualisation settings. Adding some jitter in the y values on a single hierarchical level makes it easier for nodes to pass each other laterally during the force simulation, leading to cleaner layouts. Beware of adding excessive values in either dimension, which will push nodes out of the default area for visualisation. 