### PR TITLE
Instead of lines between edges, use paths.

### DIFF
--- a/css/graphStyle.css
+++ b/css/graphStyle.css
@@ -49,11 +49,17 @@
   fill: none;
   pointer-events: all;
 }
-/*
+
 .links line {
   stroke: #999;
   stroke-opacity: 0.6;
 }
+
+path {
+  fill: none;
+}
+
+/*
 
 .nodes circle {
   stroke: #fff;

--- a/scripts/graphConf.js
+++ b/scripts/graphConf.js
@@ -39,3 +39,4 @@ const node_position_y = 'graphexpy'
 const default_edge_stroke_width = 3;
 const default_edge_color = "#CCC";
 const edge_label_color = "#111";
+const use_curved_edges = true;

--- a/scripts/graphShapes.js
+++ b/scripts/graphShapes.js
@@ -179,7 +179,7 @@ var graphShapes = (function(){
 
 	function decorate_link(edges,edgepaths,edgelabels){
 
-		var edges_deco = edges.append("line").attr("class", "edge").classed("active_edge",true)
+		var edges_deco = edges.append("path").attr("class", "edge").classed("active_edge",true)
 			.attr("source_ID",function(d) { return d.source;})
 			.attr("target_ID",function(d) { return d.target;})
 			.attr("ID",function(d) { return d.id;});

--- a/scripts/graph_viz.js
+++ b/scripts/graph_viz.js
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Main module. Handle the viualization, display data and layers.
+// Main module. Handle the visualization, display data and layers.
 
-var graph_viz = (function(){
+var graph_viz = (function () {
 	"use strict";
 
 	var _svg = {};
@@ -32,53 +32,53 @@ var graph_viz = (function(){
 
 
 
-	function init(label){
+	function init(label) {
 		_svg = d3.select(label).select("svg");
 		_svg_width = +d3.select(label).node().getBoundingClientRect().width
 		_svg_height = +d3.select(label).node().getBoundingClientRect().height;
-		_svg.attr("width",_svg_width).attr("height",_svg_height);
+		_svg.attr("width", _svg_width).attr("height", _svg_height);
 		//console.log([_svg_width,_svg_height])
 
 	}
 
 
-	function get_simulation_handle(){
+	function get_simulation_handle() {
 		return _simulation;
 	}
 
-	function svg_handle(){
+	function svg_handle() {
 		return _svg;
 	}
 
-	function nodes(){
+	function nodes() {
 		return _nodes;
 	}
 
-	function nodes_data(){
+	function nodes_data() {
 		return _Nodes;
 	}
 
-	function node_data(id){
+	function node_data(id) {
 		// return data associated to the node with id 'id'
-		for (var node in _Nodes){
+		for (var node in _Nodes) {
 			//console.log(_Nodes[node])
-			if (_Nodes[node].id==id){
+			if (_Nodes[node].id == id) {
 				var match = _Nodes[node];
 				break;
 			}
-		} 
+		}
 		return match;
 	}
 
-	function links(){
+	function links() {
 		return _links;
 	}
 
-	function links_data(){
+	function links_data() {
 		return _Links;
 	}
-	
-	function create_arrows(edge_in){
+
+	function create_arrows(edge_in) {
 		var edge_data = edge_in.data();
 		var arrow_data = _svg.selectAll('.arrow').data();
 		var data = arrow_data.concat(edge_data);
@@ -86,41 +86,41 @@ var graph_viz = (function(){
 		_svg.selectAll('.arrow')
 			.data(data)
 			.enter()
-			.append('marker')			
-			.attr('class','arrow')
-			.attr('id', function(d){return 'marker_' + d.id})
+			.append('marker')
+			.attr('class', 'arrow')
+			.attr('id', function (d) { return 'marker_' + d.id })
 			.attr('markerHeight', 5)
 			.attr('markerWidth', 5)
 			.attr('markerUnits', 'strokeWidth')
 			.attr('orient', 'auto')
-			.attr('refX', function (d){
-				 var node = node_data(d.target);
-				 return graphShapes.node_size(node)+graphShapes.node_stroke_width(node);
-				})
+			.attr('refX', function (d) {
+				var node = node_data(d.target);
+				return graphShapes.node_size(node) + graphShapes.node_stroke_width(node);
+			})
 			.attr('refY', 0)
-			.attr('viewBox',  "0 -5 10 10")
+			.attr('viewBox', "0 -5 10 10")
 			.append('svg:path')
 			.attr('d', "M0,-5L10,0L0,5")
-			.style('fill',function(d){return graphShapes.edge_color(d)});
+			.style('fill', function (d) { return graphShapes.edge_color(d) });
 	}
 
 	///////////////////////////////////////
 	// Remove force layout and data
-	function clear(){
+	function clear() {
 		console.log(_simulation)
-		if (Object.keys(_simulation).length != 0){
+		if (Object.keys(_simulation).length != 0) {
 			_simulation.stop();
 			_simulation.nodes([]);
 			_simulation.force("link").links([]);
 		}
 		_svg.selectAll("*").remove();
-		_Nodes = [],_Links =[];
+		_Nodes = [], _Links = [];
 		layers.clear_old();
 		_simulation = {};
 	}
 
 
-	function addzoom (){
+	function addzoom() {
 		// Add zoom to the svg object
 		_svg.append("rect")
 			.attr("width", _svg_width).attr("height", _svg_height)
@@ -135,69 +135,94 @@ var graph_viz = (function(){
 	}
 
 	//////////////////////////////////////////////////////////////
-	var layers = (function(){
+	var layers = (function () {
 		// Submodule that handles layers of visualization
 
 		var nb_layers = default_nb_of_layers;
 		var old_Nodes = [];
 		var old_Links = [];
 
-		function set_nb_layers(nb){
+		function set_nb_layers(nb) {
 			nb_layers = nb;
 		}
 
-		function depth(){
+		function depth() {
 			return nb_layers;
 		}
 
-		function push_layers(){
+		function push_layers() {
 			// old links and nodes become older
 			// and are moved to the next deeper layer
-			for (var k=nb_layers;k>0;k--) {
-				var kp=k-1;
-				_svg.selectAll(".old_edge"+kp).classed("old_edge"+k,true);
-				_svg.selectAll(".old_node"+kp).classed("old_node"+k,true);
-				_svg.selectAll(".old_edgepath"+kp).classed("old_edgepath"+k,true);
-				_svg.selectAll(".old_edgelabel"+kp).classed("old_edgelabel"+k,true);
+			for (var k = nb_layers; k > 0; k--) {
+				var kp = k - 1;
+				_svg.selectAll(".old_edge" + kp).classed("old_edge" + k, true);
+				_svg.selectAll(".old_node" + kp).classed("old_node" + k, true);
+				_svg.selectAll(".old_edgepath" + kp).classed("old_edgepath" + k, true);
+				_svg.selectAll(".old_edgelabel" + kp).classed("old_edgelabel" + k, true);
 			};
 		}
 
-		function clear_old(){
+		function clear_old() {
 			old_Nodes = [];
 			old_Links = [];
 		}
 
-		function update_data(d){
+		function update_data(d) {
 			// Save the data
-			var previous_nodes =  _svg.selectAll("g").filter(".active_node");
+			var previous_nodes = _svg.selectAll("g").filter(".active_node");
 			var previous_nodes_data = previous_nodes.data();
-			old_Nodes = updateAdd(old_Nodes,previous_nodes_data);
-			var previous_links =  _svg.selectAll(".active_edge");
+			old_Nodes = updateAdd(old_Nodes, previous_nodes_data);
+			var previous_links = _svg.selectAll(".active_edge");
 			var previous_links_data = previous_links.data();
-			old_Links = updateAdd(old_Links,previous_links_data);
+			old_Links = updateAdd(old_Links, previous_links_data);
 
 			// handle the pinned nodes
 			var pinned_Nodes = _svg.selectAll("g").filter(".pinned");
-			var pinned_nodes_data = pinned_Nodes.data(); 
+			var pinned_nodes_data = pinned_Nodes.data();
 			// get the node data and merge it with the pinned nodes
 			_Nodes = d.nodes;
-			_Nodes = updateAdd(_Nodes,pinned_nodes_data);
+			_Nodes = updateAdd(_Nodes, pinned_nodes_data);
 			// add coordinates to the new active nodes that already existed in the previous step
-			_Nodes = transfer_coordinates(_Nodes,old_Nodes);
+			_Nodes = transfer_coordinates(_Nodes, old_Nodes);
 			// retrieve the links between nodes and pinned nodes
 			_Links = d.links.concat(previous_links_data); // first gather the links
-			_Links = find_active_links(_Links,_Nodes); // then find the ones that are between active nodes
+			_Links = find_active_links(_Links, _Nodes); // then find the ones that are between active nodes
+			
+			// Sort links by source, then target, then label
+			// This is used to set linknum
+			_Links.sort(function (a, b) {
+				if (a.source > b.source) { return 1; }
+				else if (a.source < b.source) { return -1; }
+				else {
+					if (a.target > b.target) { return 1; }
+					if (a.target < b.target) { return -1; }
+					else {
+						if (a.label > b.label) { return 1; }
+						if (a.label < b.label) { return -1; }
+						else { return 0; }
+					}
+				}
+			});
 
+			// Any links with duplicate source and target get an incremented 'linknum'
+			for (var i = 0; i < _Links.length; i++) {
+				if (i != 0 &&
+					_Links[i].source == _Links[i - 1].source &&
+					_Links[i].target == _Links[i - 1].target) {
+					_Links[i].linknum = _Links[i - 1].linknum + 1;
+				}
+				else { _Links[i].linknum = 1; };
+			};
 		}
 
-		function updateAdd(array1,array2){
+		function updateAdd(array1, array2) {
 			// Update lines of array1 with the ones of array2 when the elements' id match
 			// and add elements of array2 to array1 when they do not exist in array1
 			var arraytmp = array2.slice(0);
 			var removeValFromIndex = [];
-			array1.forEach(function(d,index,thearray){ 
-				for(var i=0;i<arraytmp.length;i++){
-					if (d.id == arraytmp[i].id){
+			array1.forEach(function (d, index, thearray) {
+				for (var i = 0; i < arraytmp.length; i++) {
+					if (d.id == arraytmp[i].id) {
 						thearray[index] = arraytmp[i];
 						removeValFromIndex.push(i);
 					}
@@ -205,27 +230,27 @@ var graph_viz = (function(){
 			});
 			// remove the already updated values (in reverse order, not to mess up the indices)
 			removeValFromIndex.sort();
-			for (var i = removeValFromIndex.length -1; i >= 0; i--)
-				arraytmp.splice(removeValFromIndex[i],1);
+			for (var i = removeValFromIndex.length - 1; i >= 0; i--)
+				arraytmp.splice(removeValFromIndex[i], 1);
 			return array1.concat(arraytmp);
 		}
 
-		function find_active_links(list_of_links,active_nodes){
+		function find_active_links(list_of_links, active_nodes) {
 			// find the links in the list_of_links that are between the active nodes and discard the others
 			var active_links = [];
 			list_of_links.forEach(function (row) {
-				for(var i=0; i < active_nodes.length; i++ ) {
-					for(var j=0; j < active_nodes.length; j++ ) {
-						if (active_nodes[i].id==row.source.id && active_nodes[j].id==row.target.id) {
-							var L_data={source:row.source.id, target:row.target.id, type:row.type, value:row.value, id:row.id};
+				for (var i = 0; i < active_nodes.length; i++) {
+					for (var j = 0; j < active_nodes.length; j++) {
+						if (active_nodes[i].id == row.source.id && active_nodes[j].id == row.target.id) {
+							var L_data = { source: row.source.id, target: row.target.id, type: row.type, value: row.value, id: row.id };
 							var L_data = row;
 							L_data['source'] = row.source.id;
 							L_data['target'] = row.target.id;
-							active_links=active_links.concat(L_data);
+							active_links = active_links.concat(L_data);
 						}
-						else if (active_nodes[i].id==row.source && active_nodes[j].id==row.target) {
-							var L_data=row;
-							active_links=active_links.concat(L_data);
+						else if (active_nodes[i].id == row.source && active_nodes[j].id == row.target) {
+							var L_data = row;
+							active_links = active_links.concat(L_data);
 						}
 					}
 				}
@@ -233,21 +258,21 @@ var graph_viz = (function(){
 			// the active links are in active_links but there can be some duplicates
 			// remove duplicates links
 			var dic = {};
-			for ( var i=0; i < active_links.length; i++ )
-				dic[active_links[i].id]=active_links[i]; // this will remove the duplicate links (with same id)
+			for (var i = 0; i < active_links.length; i++)
+				dic[active_links[i].id] = active_links[i]; // this will remove the duplicate links (with same id)
 			var list_of_active_links = [];
 			for (var key in dic)
 				list_of_active_links.push(dic[key]);
 			return list_of_active_links;
-		} 
+		}
 
-	
-		function transfer_coordinates(Nodes, old_Nodes){
+
+		function transfer_coordinates(Nodes, old_Nodes) {
 			// Transfer coordinates from old_nodes to the new nodes with the same id
-			for ( var i=0; i < old_Nodes.length; i++ ) {
+			for (var i = 0; i < old_Nodes.length; i++) {
 				var exists = 0;
-				for(var j=0; j < Nodes.length; j++ ) {
-					if (Nodes[j].id==old_Nodes[i].id) {
+				for (var j = 0; j < Nodes.length; j++) {
+					if (Nodes[j].id == old_Nodes[i].id) {
 						Nodes[j].x = old_Nodes[i].x;
 						Nodes[j].y = old_Nodes[i].y;
 						Nodes[j].fx = old_Nodes[i].x;
@@ -260,16 +285,16 @@ var graph_viz = (function(){
 			return Nodes;
 		}
 
-		function remove_duplicates(elem_class,elem_class_old){
+		function remove_duplicates(elem_class, elem_class_old) {
 			// Remove all the duplicate nodes and edges among the old_nodes and old_edges.
 			// A node or an edge can not be on several layers at the same time.
-			d3.selectAll(elem_class).each(function(d){
-				var ID=d.id;
-				for(var n=0;n<nb_layers;n++){
-					var list_old_elements = d3.selectAll(elem_class_old+n);
+			d3.selectAll(elem_class).each(function (d) {
+				var ID = d.id;
+				for (var n = 0; n < nb_layers; n++) {
+					var list_old_elements = d3.selectAll(elem_class_old + n);
 					//list_old_nodes_data = list_old_nodes.data();
-					list_old_elements.each(function(d){
-						if(d.id==ID){
+					list_old_elements.each(function (d) {
+						if (d.id == ID) {
 							d3.select(this).remove();
 							//console.log('Removed!!')
 						}
@@ -278,45 +303,45 @@ var graph_viz = (function(){
 			});
 		}
 
-		return{
-			set_nb_layers : set_nb_layers,
-			depth:depth,
-			push_layers : push_layers,
-			clear_old:clear_old,
-			update_data : update_data,
-			remove_duplicates : remove_duplicates
+		return {
+			set_nb_layers: set_nb_layers,
+			depth: depth,
+			push_layers: push_layers,
+			clear_old: clear_old,
+			update_data: update_data,
+			remove_duplicates: remove_duplicates
 		}
 	})();
 
 	////////////////////////////////////////////////////////////////////////////////////
-	function simulation_start(center_f){
+	function simulation_start(center_f) {
 		// Define the force applied to the nodes
 		_simulation = d3.forceSimulation()
 			.force("charge", d3.forceManyBody().strength(force_strength))
-			.force("link", d3.forceLink().strength(link_strength).id(function(d) { return d.id; }));
+			.force("link", d3.forceLink().strength(link_strength).id(function (d) { return d.id; }));
 
-		if (center_f == 1){
-			var force_y=force_x_strength;
-			var force_x=force_y_strength;
+		if (center_f == 1) {
+			var force_y = force_x_strength;
+			var force_x = force_y_strength;
 			_simulation.force("center", d3.forceCenter(_svg_width / 2, _svg_height / 2));
 		}
 		else {
-			var force_y=0;
-			var force_x=0;
+			var force_y = 0;
+			var force_x = 0;
 		}
-		_simulation.force("y",d3.forceY().strength(function(d){
+		_simulation.force("y", d3.forceY().strength(function (d) {
 			return force_y;
 		}))
-		.force("x",d3.forceX().strength(function(d){
-			return force_x;
-		}));
+			.force("x", d3.forceX().strength(function (d) {
+				return force_x;
+			}));
 		return _simulation;
 	}
 
 
 
 	//////////////////////////////////////
-	function refresh_data(d,center_f,with_active_node){
+	function refresh_data(d, center_f, with_active_node) {
 		// Main visualization function
 		var svg_graph = svg_handle();
 		layers.push_layers();
@@ -324,54 +349,53 @@ var graph_viz = (function(){
 
 		//////////////////////////////////////
 		// link handling
-	 
+
 		//attach the data
 		var all_links = svg_graph.selectAll(".active_edge")
-			.data(_Links, function(d) { return d.id; });
+			.data(_Links, function (d) { return d.id; });
 		var all_edgepaths = svg_graph.selectAll(".active_edgepath")
-			.data(_Links, function(d) { return d.id; });
+			.data(_Links, function (d) { return d.id; });
 		var all_edgelabels = svg_graph.selectAll(".active_edgelabel")
-			.data(_Links, function(d) { return d.id; });
-	  
-		// links not active anymore are classified old_links
-		all_links.exit().classed("old_edge0",true).classed("active_edge",false);
-		all_edgepaths.exit().classed("old_edgepath0",true).classed("active_edgepath",false);
-		all_edgelabels.exit().classed("old_edgelabel0",true).classed("active_edgelabel",false);
+			.data(_Links, function (d) { return d.id; });
 
-		
+		// links not active anymore are classified old_links
+		all_links.exit().classed("old_edge0", true).classed("active_edge", false);
+		all_edgepaths.exit().classed("old_edgepath0", true).classed("active_edgepath", false);
+		all_edgelabels.exit().classed("old_edgelabel0", true).classed("active_edgelabel", false);
+
+
 		// handling active links associated to the data
 		var edgepaths_e = all_edgepaths.enter(),
 			edgelabels_e = all_edgelabels.enter(),
 			link_e = all_links.enter();
-		var decor_out = graphShapes.decorate_link(link_e,edgepaths_e,edgelabels_e);
+		var decor_out = graphShapes.decorate_link(link_e, edgepaths_e, edgelabels_e);
 		_links = decor_out[0];
 
-		var	edgepaths = decor_out[1],
+		var edgepaths = decor_out[1],
 			edgelabels = decor_out[2];
 
-	
+
 		// previous links plus new links are merged
 		_links = _links.merge(all_links);
 		edgepaths = edgepaths.merge(all_edgepaths);
 		edgelabels = edgelabels.merge(all_edgelabels);
 
-
 		///////////////////////////////////
 		// node handling
 
 		var all_nodes = svg_graph.selectAll("g").filter(".active_node")
-			.data(_Nodes, function(d) { return d.id; });
+			.data(_Nodes, function (d) { return d.id; });
 
 		//console.log(data_node);
 		// old nodes not active any more are tagged
-		all_nodes.exit().classed("old_node0",true).classed("active_node",false);//;attr("class","old_node0");
+		all_nodes.exit().classed("old_node0", true).classed("active_node", false);//;attr("class","old_node0");
 
 
 		// nodes associated to the data are constructed
 		_nodes = all_nodes.enter();
 
 		// add node decoration
-		var node_deco = graphShapes.decorate_node(_nodes,with_active_node);
+		var node_deco = graphShapes.decorate_node(_nodes, with_active_node);
 
 		var _nodes = node_deco.merge(all_nodes);
 
@@ -384,17 +408,17 @@ var graph_viz = (function(){
 		svg_graph.selectAll("g").filter(".pinned").moveToFront();
 
 
-		layers.remove_duplicates(".active_node",".old_node");
-		layers.remove_duplicates(".active_edge",".old_edge");
-		layers.remove_duplicates(".active_edgepath",".old_edgepath");
-		layers.remove_duplicates(".active_edgelabel",".old_edgelabel");
+		layers.remove_duplicates(".active_node", ".old_node");
+		layers.remove_duplicates(".active_edge", ".old_edge");
+		layers.remove_duplicates(".active_edgepath", ".old_edgepath");
+		layers.remove_duplicates(".active_edgelabel", ".old_edgelabel");
 
 
 		///////////////////////////////
 		// Force simulation
 		// simulation model and parameters
-	
-	
+
+
 		_simulation = simulation_start(center_f);
 		// Associate the simulation with the data
 		_simulation.nodes(_Nodes).on("tick", ticked);
@@ -405,16 +429,28 @@ var graph_viz = (function(){
 		// handling simulation steps
 		// move the nodes and links at each simulation step, following this rule:
 		function ticked() {
-			_links
-				.attr("x1", function(d) { return d.source.x; })
-				.attr("y1", function(d) { return d.source.y; })
-				.attr("x2", function(d) { return d.target.x; })
-				.attr("y2", function(d) { return d.target.y; });
+			_links.attr('d', function (d) {
+				if (use_curved_edges) {
+					var dx = d.target.x - d.source.x;
+					var dy = d.target.y - d.source.y;
+					var dr = Math.sqrt((dx * dx + dy * dy) / d.linknum);
+					return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y;
+				} else {
+					return "M" + d.source.x + "," + d.source.y + "L" + d.target.x + "," + d.target.y;
+				}
+			});
 			_nodes
-				.attr("transform", function(d) { return "translate(" + d.x + ", " + d.y + ")"; }); 
+				.attr("transform", function (d) { return "translate(" + d.x + ", " + d.y + ")"; });
 
 			edgepaths.attr('d', function (d) {
-				return 'M ' + d.source.x + ' ' + d.source.y + ' L ' + d.target.x + ' ' + d.target.y;
+				if (use_curved_edges) {
+					var dx = d.target.x - d.source.x;
+					var dy = d.target.y - d.source.y;
+					var dr = Math.sqrt((dx * dx + dy * dy) / d.linknum);
+					return "M" + d.source.x + "," + d.source.y + "A" + dr + "," + dr + " 0 0,1 " + d.target.x + "," + d.target.y;
+				} else {
+					return "M" + d.source.x + "," + d.source.y + "L" + d.target.x + "," + d.target.y;
+				}
 			});
 
 			edgelabels.attr('transform', function (d) {
@@ -434,14 +470,14 @@ var graph_viz = (function(){
 	}
 
 
-	function get_node_edges(node_id){
+	function get_node_edges(node_id) {
 		// Return the in and out edges of node with id 'node_id'
 		var connected_edges = d3.selectAll(".edge").filter(
-			function(item){
-				if (item.source==node_id || item.source.id==node_id){
+			function (item) {
+				if (item.source == node_id || item.source.id == node_id) {
 					return item;
 				}
-				else if (item.target==node_id || item.target.id==node_id){
+				else if (item.target == node_id || item.target.id == node_id) {
 					return item;
 				}
 			});
@@ -449,7 +485,7 @@ var graph_viz = (function(){
 	}
 
 
-	var graph_events = (function (){
+	var graph_events = (function () {
 		//////////////////////////////////
 		// Handling mouse events
 
@@ -462,63 +498,63 @@ var graph_viz = (function(){
 		function dragged(d) {
 			var connected_edges = get_node_edges(d.id);
 			var f_connected_edges = connected_edges.filter("*:not(.active_edge)")
-			if(f_connected_edges._groups[0].length==0){
+			if (f_connected_edges._groups[0].length == 0) {
 				d.fx = d3.event.x;
 				d.fy = d3.event.y;
 			}
-			else{
+			else {
 				f_connected_edges
-					.style("stroke-width",function(){return parseInt(d3.select(this).attr("stroke-width"))+2;})
-					.style("stroke-opacity",1)
-					.classed("blocking",true)
+					.style("stroke-width", function () { return parseInt(d3.select(this).attr("stroke-width")) + 2; })
+					.style("stroke-opacity", 1)
+					.classed("blocking", true)
 			}
 		}
 
 		function dragended(d) {
 			if (!d3.event.active) _simulation.alphaTarget(0);
 			d3.selectAll(".blocking")
-				.style("stroke-width",function(){return d3.select(this).attr("stroke-width");})
-				.style("stroke-opacity",function(){return d3.select(this).attr("stroke-opacity");})
-				.classed("blocking",false)
+				.style("stroke-width", function () { return d3.select(this).attr("stroke-width"); })
+				.style("stroke-opacity", function () { return d3.select(this).attr("stroke-opacity"); })
+				.classed("blocking", false)
 			// d.fx = null;
 			// d.fy = null;
 		}
 
 		function clicked(d) {
 			d3.select(".focus_node").remove();
-			var input = document.getElementById ("freeze-in");
+			var input = document.getElementById("freeze-in");
 			var isChecked = input.checked;
 			if (isChecked) infobox.display_info(d);
 			else {
 				_simulation.stop();
 				// remove the oldest links and nodes
-				var stop_layer = layers.depth()-1;
-				_svg.selectAll(".old_node"+stop_layer).remove();
-				_svg.selectAll(".old_edge"+stop_layer).remove();
-				_svg.selectAll(".old_edgepath"+stop_layer).remove();
-				_svg.selectAll(".old_edgelabel"+stop_layer).remove();
+				var stop_layer = layers.depth() - 1;
+				_svg.selectAll(".old_node" + stop_layer).remove();
+				_svg.selectAll(".old_edge" + stop_layer).remove();
+				_svg.selectAll(".old_edgepath" + stop_layer).remove();
+				_svg.selectAll(".old_edgelabel" + stop_layer).remove();
 				infobox.display_info(d);
-				graphioGremlin.click_query(d);              
+				graphioGremlin.click_query(d);
 				console.log('event!!')
 			}
 		}
 
 
-		function pin_it(d){
-			d3.event.stopPropagation();		
+		function pin_it(d) {
+			d3.event.stopPropagation();
 			var node_pin = d3.select(this);
 			var pinned_node = d3.select(this.parentNode);
 			//console.log('Pinned!')
 			//console.log(pinned_node.classed("node"));
-			if (pinned_node.classed("active_node")){
-				if (!pinned_node.classed("pinned")){
-					pinned_node.classed("pinned",true);
+			if (pinned_node.classed("active_node")) {
+				if (!pinned_node.classed("pinned")) {
+					pinned_node.classed("pinned", true);
 					console.log('Pinned!');
 					node_pin.attr("fill", "#000");
 					pinned_node.moveToFront();
 				}
 				else {
-					pinned_node.classed("pinned",false);
+					pinned_node.classed("pinned", false);
 					console.log('Unpinned!');
 					node_pin.attr("fill", graphShapes.node_color);
 				}
@@ -526,31 +562,31 @@ var graph_viz = (function(){
 		}
 
 		return {
-			dragstarted:dragstarted,
-			dragged:dragged,
-			dragended:dragended,
-			clicked:clicked,
-			pin_it:pin_it
+			dragstarted: dragstarted,
+			dragged: dragged,
+			dragended: dragended,
+			clicked: clicked,
+			pin_it: pin_it
 		}
 
 	})();
 
 	return {
-		svg_handle : svg_handle,
-		nodes : nodes,
-		links : links,
-		nodes_data : nodes_data,
-		node_data : node_data,
-		links_data : links_data,
-		init : init,
-		create_arrows : create_arrows,
-		addzoom : addzoom,
-		clear : clear,
-		get_simulation_handle : get_simulation_handle,
-		simulation_start : simulation_start,
-		refresh_data : refresh_data,
-		layers : layers,
-		graph_events : graph_events
+		svg_handle: svg_handle,
+		nodes: nodes,
+		links: links,
+		nodes_data: nodes_data,
+		node_data: node_data,
+		links_data: links_data,
+		init: init,
+		create_arrows: create_arrows,
+		addzoom: addzoom,
+		clear: clear,
+		get_simulation_handle: get_simulation_handle,
+		simulation_start: simulation_start,
+		refresh_data: refresh_data,
+		layers: layers,
+		graph_events: graph_events
 	};
 
 })();


### PR DESCRIPTION
This should address Issues #35 and #13

For each link/edge between nodes, calculate a linknum. This is used to
adjust the arc between nodes so that multiple edges between nodes don't
overlap.

in graphConf there's a use_curved_edges variable. Setting to true will
enable curved edges.

Tweaked the CSS so that paths display and aren't filled.

I also auto-linted graph_viz.js at some point which made a bunch of
spacing changes, didn't realize at the time that this might be an issue.