### PR TITLE
Relative dependency URLs

### DIFF
--- a/graphexp.html
+++ b/graphexp.html
@@ -10,11 +10,11 @@
 <!--<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="font-awesome-4.7.0/css/font-awesome.min.css">-->
 
-<script src="http://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="//code.jquery.com/jquery-3.2.1.min.js"></script>
 <!--<script src="jquery-3.2.1.min.js"></script>-->
 
 <script src="scripts/utils.js"></script>
-<script src="http://d3js.org/d3.v4.min.js"></script>
+<script src="//d3js.org/d3.v4.min.js"></script>
 <!--<script src="d3/d3.min.js"></script>-->
 <script src="scripts/graphConf.js"></script>
 <script src="scripts/graphShapes.js"></script>


### PR DESCRIPTION
I've updated graphexp.html to use relative URLs for the d3 and jquery dependencies. This was causing a problem when loading the app with https.