### PR TITLE
Strict ID comparison to avoid exclude nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 d3/
 font-awesome-4.7.0/
 jquery*

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -442,7 +442,7 @@ var graphioGremlin = (function(){
 	  // find the element in list with id equal to elem
 	  // return its index or null if there is no
 	  for (var i=0;i<list.length;i++) {
-		if (list[i].id == elem) return i;
+		if (list[i].id === elem) return i;
 	  }
 	  return null;
 	}  

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -172,7 +172,7 @@ var graphioGremlin = (function(){
         var edge_filter = $('#edge_filter').val();
         var communication_method = $('#communication_method').val();
 		var id = d.id;
-		if(isNaN(id)){ // Add quotes if id is a string (not a number).
+		if (typeof id === 'string' || id instanceof String) { // Add quotes if id is a string (not a number).
 			id = '"'+id+'"';
 		}
 		// Gremlin query


### PR DESCRIPTION
If two nodes have IDs like 0 and "0000", the second node is not added to the graph because the comparison is not strict. This make D3 fail adding links because it makes a strict comparison of the IDs and it doesn't find the node.

This problem is solved just making the `idIndex` comparison strict.

There was also a problem when the data for the "0000" node was retrieved. Due to it's a number, it wasn't add quotes to the query and it doesn't work. A strict type comparison has been added.