### PR TITLE
AddsHTTPS support for REST protocol for AWS Neptune.

### DIFF
--- a/scripts/graphConf.js
+++ b/scripts/graphConf.js
@@ -8,6 +8,9 @@ const host = false;
 // For implementations like Neptune where only single commands are allowed per request
 // set to true
 const SINGLE_COMMANDS_AND_NO_VARS = false;
+// For implementations like Neptune where communication only over https is allowed
+// set to true
+const REST_USE_HTTPS = false;
 
 // Time out for the REST protocol. Increase it if the graphDB is slow.
 const REST_TIMEOUT = 2000 

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -216,7 +216,11 @@ var graphioGremlin = (function(){
 		let server_port = $('#server_port').val();
 		let COMMUNICATION_PROTOCOL = $('#server_protocol').val();
 			if (COMMUNICATION_PROTOCOL == 'REST'){
-				let server_url = "https://"+server_address+":"+server_port;
+				if(REST_USE_HTTPS){
+					let server_url = "https://"+server_address+":"+server_port;
+				} else{
+					let server_url = "http://"+server_address+":"+server_port;
+				}
 				run_ajax_request(gremlin_query,server_url,query_type,active_node,message,callback);
 			}
 			else if (COMMUNICATION_PROTOCOL == 'websocket'){

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -216,7 +216,7 @@ var graphioGremlin = (function(){
 		let server_port = $('#server_port').val();
 		let COMMUNICATION_PROTOCOL = $('#server_protocol').val();
 			if (COMMUNICATION_PROTOCOL == 'REST'){
-				let server_url = "http://"+server_address+":"+server_port;
+				let server_url = "https://"+server_address+":"+server_port;
 				run_ajax_request(gremlin_query,server_url,query_type,active_node,message,callback);
 			}
 			else if (COMMUNICATION_PROTOCOL == 'websocket'){


### PR DESCRIPTION
In trying to connect to a AWS Neptune remote database, I had to change the REST server url to `https` It seems like the new version of Neptune uses https now by default. This PR adds this to `graphioGremlin.js` currently, but I could see placing this in `graphConf.js` if that's the preferred method.

Some information if others are encountering the same issue (or maybe I did something horribly wrong). Users can tell if their Neptune cluster responds to https or http requests by trying the following commands (in their Bastion ec2 instance).
- `curl http://<your endpoint>:8182/status`
- `curl https://<your endpoint>:8182/status` 

After following instructions in [1], users could also try (in their browser on their local machine, __after__ setting up the ssh tunnel through their bastion host) the links `http://localhost:8182/status` or `https://localhost:8182/status` to diagnose this issue. For me, only https worked.

1. [Link](https://aws.amazon.com/premiumsupport/knowledge-center/neptune-gremlin-graph-graphexp/) to connecting a local graphexp instance to remote AWS Neptune server via a Bastion Host.