### PR TITLE
Utility function for flushing local db

### DIFF
--- a/graphexp.html
+++ b/graphexp.html
@@ -164,7 +164,8 @@
 					<div class="nav input_unit_container", id="editGraph" style="display:none;">
 					     <button onclick="addVertexForm()"   style="height:25px; width:150px" > Add Vertex </button><br>
 					     <button onclick="editVertexForm()"  style="height:25px; width:150px" > Edit Vertex </button><br>
-					     <button onclick="addEditEdgeForm()"     style="height:25px; width:150px" > Add/Edit Edge </button><br>
+						 <button onclick="addEditEdgeForm()"     style="height:25px; width:150px" > Add/Edit Edge </button><br>
+						 <button onclick="flush()"     style="height:25px; width:150px" > Flush </button><br>
 					</div>
 					
 					<div class="nav input_unit_container", id="addVertexForm" style="display:none;">

--- a/scripts/editGraph.js
+++ b/scripts/editGraph.js
@@ -126,5 +126,10 @@
 		editGraph();
 		}
 	}
+
+	function flush() {
+		const gremlin_query = "g.V().drop().iterate()"
+		graphioGremlin.send_to_server(gremlin_query, 'flushGraph', null, "")
+	}
 	
 	

--- a/scripts/graphioGremlin.js
+++ b/scripts/graphioGremlin.js
@@ -344,6 +344,13 @@ var graphioGremlin = (function(){
 			}
 			var data = response.result.data;
 			if (data == null){
+				// No response data expected for flush query, so just validate status code.
+				if (query_type == 'flushGraph' && response.status.code == 204) {
+					$('#outputArea').html("<p> Successfully flushed existing DB data.</p>");
+					$('#messageArea').html('');
+					return
+				}
+
 				if (query_type == 'editGraph'){
 					$('#outputArea').html(response.status.message);
 					$('#messageArea').html('Could not write data to DB.' +


### PR DESCRIPTION
This PR provides a utility button for flushing all existing vertices/edges in the db (housed within the already-existing "Edit Graph" panel).

I've been working on a project that runs Gremlin in a Docker container, so in development/testing scenarios I would restart docker-compose to flush the local db which would get annoying when continuously making changes to model objects that would be written to the db. As an alternative we also have a utility script that shells into the running container, connects to the Gremlin server, and then flushes the db.

Something like this could come in handy for these development scenarios I described above, so I thought I would go ahead and PR it.
