### PR TITLE
Add Dockerfile to easily publish a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM httpd:2
+COPY ./ /usr/local/apache2/htdocs/


### PR DESCRIPTION
By adding this Dockerfile, one can easily build a container by using `docker build` and publish it afterwards on the [Docker Hub](https://hub.docker.com).
```
docker build . -t bricaud/graphexp 
```
This is needed as the [joov/gremlin-demo](https://github.com/joov/gremlin-demo) repository mentioned in the documentation still does not offer a published container and is uselessly complicated.

As an example, I published the [0xthiebaut/graphexp](https://hub.docker.com/r/0xthiebaut/graphexp) container allowing this repository to be ran using `docker run`.
```
docker run --rm -dit -p 8080:80 0xthiebaut/graphexp
```

There are currently just under 20 versions of graphexp on Docker, a version owned and maintained by the author @bricaud would be appreciated. 
 